### PR TITLE
Build with go-pie

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,11 +1,11 @@
 pkgbase = lxd
 	pkgdesc = REST API, command line tool and OpenStack integration plugin for LXC.
 	pkgver = 2.21
-	pkgrel = 3
+	pkgrel = 4
 	url = https://github.com/lxc/lxd
 	arch = x86_64
 	license = APACHE
-	makedepends = go
+	makedepends = go-pie
 	makedepends = git
 	depends = lxc
 	depends = squashfs-tools

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,14 +3,14 @@
 
 pkgname=lxd
 pkgver=2.21
-pkgrel=3
+pkgrel=4
 pkgdesc="REST API, command line tool and OpenStack integration plugin for LXC."
 arch=('x86_64')
 url="https://github.com/lxc/lxd"
 license=('APACHE')
 conflicts=('lxd-lts')
 depends=('lxc' 'squashfs-tools' 'dnsmasq' 'sqlite')
-makedepends=('go' 'git')
+makedepends=('go-pie' 'git')
 options=('!strip' '!emptydirs')
 optdepends=(
     'lvm2: for lvm2 support'


### PR DESCRIPTION
Packages in the official repositories were recently rebuild with
go-pie. This enables PIE build mode by default. This changes
lxd to build with go-pie by default. I didn't test it thourghly,
but after restarting lxd.service and creating a container it
seemed to work.