### PR TITLE
Depend on dqlite, not dqlite-git

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = lxd
 	pkgdesc = REST API, command line tool and OpenStack integration plugin for LXC.
 	pkgver = 3.4
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/lxc/lxd
 	arch = x86_64
 	license = APACHE
@@ -10,7 +10,7 @@ pkgbase = lxd
 	depends = lxc
 	depends = squashfs-tools
 	depends = dnsmasq
-	depends = dqlite-git
+	depends = dqlite
 	optdepends = lvm2: for lvm2 support
 	optdepends = thin-provisioning-tools: for thin provisioning support
 	optdepends = btrfs-progs: for btrfs support

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,13 +3,13 @@
 
 pkgname=lxd
 pkgver=3.4
-pkgrel=1
+pkgrel=2
 pkgdesc="REST API, command line tool and OpenStack integration plugin for LXC."
 arch=('x86_64')
 url="https://github.com/lxc/lxd"
 license=('APACHE')
 conflicts=('lxd-lts')
-depends=('lxc' 'squashfs-tools' 'dnsmasq' 'dqlite-git')
+depends=('lxc' 'squashfs-tools' 'dnsmasq' 'dqlite')
 makedepends=('go-pie' 'git')
 options=('!strip' '!emptydirs')
 optdepends=(


### PR DESCRIPTION
LXD should depend on a pinned version of dqlite, not the git master.
And since dqlite-git provides dqlite, a user can still use the git
master if he/she wishes.