### PR TITLE
Add missing dependency lxcfs

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,14 +8,14 @@
 pkgname=lxd
 _pkgname=lxd
 pkgver=3.17
-pkgrel=1
+pkgrel=2
 pkgdesc="REST API, command line tool and OpenStack integration plugin for LXC."
 arch=('x86_64')
 url="https://github.com/lxc/lxd"
 license=('APACHE')
 conflicts=('lxd-git' 'lxd-lts')
 provides=('lxd')
-depends=('lxc' 'squashfs-tools' 'dnsmasq' 'libuv')
+depends=('lxc' 'lxcfs' 'squashfs-tools' 'dnsmasq' 'libuv')
 makedepends=('go' 'git' 'tcl' 'patchelf')
 optdepends=(
     'lvm2: for lvm2 support'


### PR DESCRIPTION
lxcfs can provide correct /proc/cpuinfo and many other /proc resources for containers.

(also see: https://discuss.linuxcontainers.org/t/limits-cpu-limit-not-working/5613/5 )



## Checklist:

Please ensure you've done the below when submitting a pull request:

- [ ] Run `updpkgsums` to ensure checksums are up to date.
- [ ] Make and install changes locally.
- [ ] Bump `_pkgrel` if change is not an upstream update.
- [ ] Reset `_pkgrel` to 1 if `_pkgver` has changed.
- [ ] Run `makepkg --printsrcinfo > .SRCINFO` to update AUR info file (do this last).
